### PR TITLE
Move hook registration outside of construction, so the class is more generally useful

### DIFF
--- a/includes/class-fix-image-rotation.php
+++ b/includes/class-fix-image-rotation.php
@@ -53,15 +53,13 @@ if ( ! class_exists( 'Fix_Image_Rotation' ) ) {
 		protected static $instance = null;
 
 		/**
-		 * Lets get started with the construct, registers hooks
-		 * needed for the plugin.
+		 * Constructs the plugin object and initializes its variables.
 		 *
 		 * @since 1.0
 		 */
 		public function __construct() {
 			$this->orientation_fixed = array();
 			$this->previous_meta     = array();
-			$this->register_hooks();
 		}
 
 		/**
@@ -320,6 +318,4 @@ if ( ! class_exists( 'Fix_Image_Rotation' ) ) {
 		}
 
 	}
-
-	Fix_Image_Rotation::get_instance();
 }

--- a/init.php
+++ b/init.php
@@ -23,3 +23,5 @@ if ( ! defined( 'GS_FIR_PATH' ) ) {
 }
 
 require_once GS_FIR_PATH . 'includes/class-fix-image-rotation.php';
+
+Fix_Image_Rotation::get_instance()->register_hooks();


### PR DESCRIPTION
By moving the registration out of the class file, the class file could be included without triggering hooks. This might be useful if someone wanted to use this class for image resizing, but on different hooks (say for fixing issues in a plugin's custom upload code). It's also just a good practice to make hook registration a separate and intentional step. Class files should merely define a class.