### PR TITLE
prevent undefined function call

### DIFF
--- a/includes/class-fix-image-rotation.php
+++ b/includes/class-fix-image-rotation.php
@@ -270,7 +270,7 @@ if ( ! class_exists( 'Fix_Image_Rotation' ) ) {
 			$editor = wp_get_image_editor( $file );
 
 			// If GD Library is being used, then we need to store metadata to restore later.
-			if ( 'WP_Image_Editor_GD' === get_class( $editor ) ) {
+			if ( 'WP_Image_Editor_GD' === get_class( $editor ) && is_callable( 'wp_read_image_metadata' ) ) {
 				$this->previous_meta[ $file ] = wp_read_image_metadata( $file );
 			}
 


### PR DESCRIPTION
Uploading images shot with an iPhone 7. Got a warning about Illegal IFD size, and then an undefined function call to wp_read_image_metadata which, for some reason, didn't exist while the image editor instance did. Adding a check to ensure that wp_read_image_metadata is callable before trying to call it.